### PR TITLE
Implement cached content verification for file content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 tsd_api_lib.egg-info/
 build/
 dist/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+
+# tsd-api-lib
+
+Tools to build the TSD API, and its clients. Currently includes:
+
+* Simple, efficient content verification of files and directories of files, with configurable caching, based on [blake3](https://github.com/BLAKE3-team/BLAKE3).
+
+## Usage
+
+Basic usage:
+```python
+from tsdapilib.verifier import ContentVerifier
+
+cv = ContentVerifier()
+cv.check_file("/my/file")
+```
+
+Performing incremental hashing, with a persistent cache, which can be shared across processes:
+```python
+from tsdapilib.verifier import ContentVerifier
+from tsdapilib.backends import PostgresBackend
+
+postgres_config = {
+    "dbname": "some-db",
+    "user": "some-user",
+    "pw": "some-pw",
+    "host": "some-host",
+}
+cv = ContentVerifier(backend=PostgresBackend(postgres_config))
+
+cv.start("large-file")
+with cv._lazy_read("large-file", chunk_size=1024) as f:
+    # serve the chunk over the network
+    # do something else with it
+    cv.update("large-file", chunk)
+hash_value = cv.finish("large-file")
+# communicte the hash_value
+```
+
+The library also provides a `SQLiteBackend` persistent cache as a more lightweight alternative to the `PostgresBackend`.
+
+## Testing
+
+To run the tests, do:
+```bash
+pip3 install pytest
+pytest tsdapilib/tests.py
+```
+
+## License
+
+BSD.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+setup(
+    name='tsd-api-lib',
+    version='0.0.1',
+    description='tsdapililb - tools for building APIs and clients',
+    author='Leon du Toit',
+    author_email='l.c.d.toit@usit.uio.no',
+    url='https://github.com/unioslo/tsd-api-lib',
+    packages=['tsdapilib'],
+    install_requires=['blake3'],
+    python_requires='>=3.6',
+
+)

--- a/tsdapilib/backends.py
+++ b/tsdapilib/backends.py
@@ -1,0 +1,265 @@
+
+import psycopg2
+import psycopg2.extensions
+import psycopg2.pool
+import sqlite3
+
+from collections import OrderedDict
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from typing import Optional, ContextManager, Any
+
+
+class GenericBackend(object):
+
+    def __init__(self, config: dict = {}, stale_after: int = 24) -> None:
+        self._init_backend(config)
+        self.purge()
+        self._config = config
+        self._stale_after = stale_after
+
+    @property
+    def config(self) -> dict:
+        return self._config
+
+    @property
+    def stale_after(self) -> int:
+        return self._stale_after
+
+    def _init_backend(self, config: dict) -> None:
+        raise NotImplementedError
+
+    def _put(self, reference: str, content_hash: str, stale_after: int) -> bool:
+        # simple, atomic, idempotent put
+        raise NotImplementedError
+
+    def _get(self, reference: str) -> Optional[dict]:
+        # simple, atomic get
+        raise NotImplementedError
+
+    def _clean(self) -> bool:
+        raise NotImplementedError
+
+    # public methods
+
+    def store(self, reference: str, content_hash: str) -> bool:
+        """
+        Persist a content reference and its hash digest,
+        along with the time after which it should be considered stale.
+
+        """
+        stale_after = int((datetime.now() + timedelta(hours=self.stale_after)).timestamp())
+        return self._put(reference, content_hash, stale_after)
+
+    def fetch(self, reference: str) -> Optional[dict]:
+        """
+        Fetch a reference, its hash, and expiry time from the store.
+        If there is not item corresponding to the reference, or if
+        the reference has become stale, then return None.
+
+        """
+        now = datetime.now().timestamp()
+        item = self._get(reference)
+        if not item:
+            return None
+        elif now > item.get('stale_after'):
+            return None
+        else:
+            return item
+
+    def purge(self) -> None:
+        """
+        Remove all stale entries, in bulk.
+
+        """
+        return self._clean()
+
+
+class EphemeralBackend(GenericBackend):
+
+    storage = OrderedDict()
+
+    def _init_backend(self, config: dict) -> None:
+        pass # nothing to do here
+
+    def _put(self, reference: str, content_hash: str, stale_after: int) -> bool:
+        self.storage[reference] = {
+            'reference': reference,
+            'content_hash': content_hash,
+            'stale_after': stale_after,
+        }
+
+    def _get(self, reference: str) -> Optional[dict]:
+        return self.storage.get('reference')
+
+    def _clean(self) -> None:
+        new = {}
+        now = datetime.now().timestamp()
+        for k,v in self.storage:
+            if now < v.get('stale_after'):
+                new[k] = v
+        self.storage = new
+
+
+class GenericDataBaseBackend(GenericBackend):
+
+    table_definition = """
+        content_hashes(
+            reference text unique not null,
+            content_hash text not null,
+            stale_after int not null
+        )
+    """
+
+    def _init_backend(self, config: dict) -> None:
+        self.engine = self._db_init(config)
+        with self._session_scope(self.engine) as session:
+            session.execute(f"create table if not exists {self.table_definition}")
+
+    def _put(self, reference: str, content_hash: str, stale_after: int) -> bool:
+        with self._session_scope(self.engine) as session:
+            session.execute(
+                self._gen_put_sql(),
+                {
+                    "reference": reference,
+                    "content_hash": content_hash,
+                    "stale_after": stale_after,
+                }
+            )
+        return True
+
+    def _get(self, reference: str) -> Optional[dict]:
+        rows = []
+        with self._session_scope(self.engine) as session:
+            session.execute(
+                self._gen_get_sql(),
+                {"reference": reference}
+            )
+            rows = session.fetchall()
+            cols = [desc[0] for desc in session.description]
+        if not rows:
+            return None
+        else:
+            item = {}
+            for k,v in zip(cols, rows[0]):
+                item[k] = v
+            return item
+
+    def _clean(self) -> None:
+        with self._session_scope(self.engine) as session:
+            session.execute(
+                self._gen_clean_sql(),
+                {"now": datetime.now().timestamp()}
+            )
+
+    def _db_init(self, config: dict) -> Any:
+        # return a db engine
+        raise NotImplementedError
+
+    @contextmanager
+    def _session_scope(self, engine: Any) -> ContextManager[Any]:
+        # return a transactional scope
+        raise NotImplementedError
+
+    def _gen_put_sql(self) -> str:
+        raise NotImplementedError
+
+    def _gen_get_sql(self) -> str:
+        raise NotImplementedError
+
+    def _gen_clean_sql(self) -> str:
+        raise NotImplementedError
+
+
+class SQLiteBackend(GenericDataBaseBackend):
+
+    def _db_init(
+        self,
+        config: dict,
+    ) -> sqlite3.Connection:
+        path = config.get('path')
+        dbname = config.get('name')
+        dburl = 'sqlite:///' + path + '/' + dbname
+        engine = sqlite3.connect(path + '/' + dbname)
+        return engine
+
+    @contextmanager
+    def _session_scope(
+        self,
+        engine: sqlite3.Connection,
+    ) -> ContextManager[sqlite3.Cursor]:
+        session = engine.cursor()
+        try:
+            yield session
+            session.close()
+        except Exception as e:
+            session.close()
+            engine.rollback()
+            raise e
+        finally:
+            session.close()
+            engine.commit()
+
+    def _gen_put_sql(self) -> str:
+        return """
+            insert into content_hashes (reference, content_hash, stale_after)
+            values (:reference, :content_hash, :stale_after)
+            on conflict (reference) do update
+            set content_hash = excluded.content_hash,
+            stale_after = excluded.stale_after
+            where reference = excluded.reference
+        """
+        # how to get returning working
+
+    def _gen_get_sql(self) -> str:
+        return "select * from content_hashes where reference = :reference"
+
+    def _gen_clean_sql(self) -> str:
+        return "delete from content_hashes where :now > stale_after"
+
+
+class PostgreSQLBackend(GenericDataBaseBackend):
+
+    def _db_init(self, config: dict) -> psycopg2.pool.SimpleConnectionPool:
+        min_conn = 2
+        max_conn = 5
+        dsn = f"dbname={config['dbname']} user={config['user']} password={config['pw']} host={config['host']}"
+        pool = psycopg2.pool.SimpleConnectionPool(
+            min_conn, max_conn, dsn,
+        )
+        return pool
+
+    @contextmanager
+    def _session_scope(
+        self,
+        pool: psycopg2.pool.SimpleConnectionPool,
+    ) -> ContextManager[psycopg2.extensions.cursor]:
+        engine = pool.getconn()
+        session = engine.cursor()
+        try:
+            yield session
+            session.close()
+        except Exception as e:
+            session.close()
+            engine.rollback()
+            raise e
+        finally:
+            session.close()
+            engine.commit()
+            pool.putconn(engine)
+
+    def _gen_put_sql(self) -> str:
+        return """
+            insert into content_hashes (reference, content_hash, stale_after)
+            values (%(reference)s, %(content_hash)s, %(stale_after)s)
+            on conflict (reference) do update
+            set content_hash = excluded.content_hash,
+            stale_after = excluded.stale_after
+            where content_hashes.reference = excluded.reference
+        """
+
+    def _gen_get_sql(self) -> str:
+        return "select * from content_hashes where reference = %(reference)s"
+
+    def _gen_clean_sql(self) -> str:
+        return "delete from content_hashes where %(now)s > stale_after"

--- a/tsdapilib/exc.py
+++ b/tsdapilib/exc.py
@@ -1,0 +1,24 @@
+
+# content verifier
+
+class ContentVerificationError(Exception):
+    # base exception
+    pass
+
+class ContentVerificationReadError(ContentVerificationError):
+    # raised if we read too many bytes of a file.
+    pass
+
+class ContentVerificationMissingReferenceError(ContentVerificationError):
+    # raised when a reference does not resolve to a path
+    pass
+
+class ContentVerificationReferenceTypeError(ContentVerificationError):
+    # raised when finding a file, but expecting a directory
+    # and vice versa.
+    pass
+
+class ContentVerificationMissingHashError(ContentVerificationError):
+    # raise during incremental processing, if there is no
+    # state for th givn reference, i.e. start() was not called.
+    pass

--- a/tsdapilib/tests.py
+++ b/tsdapilib/tests.py
@@ -1,0 +1,239 @@
+
+import os
+import pytest
+import shutil
+import time
+
+from datetime import datetime, timedelta
+
+import blake3
+import psycopg2
+
+from tsdapilib.verifier import ContentVerifier
+from tsdapilib.backends import GenericBackend, SQLiteBackend, PostgreSQLBackend
+
+class Resources(object):
+
+    def __init__(self, work_dir: str) -> None:
+        """
+        Creates:
+
+        /tmp/{work_dir}
+        /tmp/{work_dir}/f1
+        /tmp/{work_dir}/d1
+        /tmp/{work_dir}/d1/f2
+        /tmp/{work_dir}/d1/f3
+        /tmp/{work_dir}/d2
+        /tmp/{work_dir}/d2/f4
+
+        """
+        base_dir = '/tmp'
+        target_dir = f'{base_dir}/{work_dir}'
+        try:
+            shutil.rmtree(target_dir)
+        except FileNotFoundError:
+            pass
+        self.target_dir = target_dir
+        self.references = {}
+        d1 = f'{target_dir}/d1'
+        d2 = f'{target_dir}/d2'
+        os.makedirs(d1)
+        os.makedirs(d2)
+        self.references['directories'] = {
+            'target_dir': target_dir,
+            'd1': d1,
+            'd2': d2,
+        }
+        f1 = f'{target_dir}/f1'
+        f2 = f'{d1}/f2'
+        f3 = f'{d1}/f3'
+        f4 = f'{d2}/f4'
+        with open(f1, 'wb') as f:
+            f.write(b'Thus I have heard')
+        with open(f2, 'wb') as f:
+            f.write(b'This is unease')
+        with open(f3, 'wb') as f:
+            f.write(b'This is the cessation of unease')
+        with open(f4, 'wb') as f:
+            f.write(b'This is the path to the cessation of unease')
+        self.references['files'] = {
+            'f1': f1,
+            'f2': f2,
+            'f3': f3,
+            'f4': f4,
+        }
+
+    def __enter__(self) -> dict:
+        return self.references
+
+    def __exit__(self, type, value, traceback) -> None:
+        shutil.rmtree(self.target_dir)
+
+
+class TestContentVerifier(object):
+
+    work_dir = 'test-content-verifier'
+
+    def test_verifier_ephemeral(self) -> None:
+        with Resources(self.work_dir) as r:
+
+            # operations on single files
+            f1 = r.get('files').get('f1')
+            f2 = r.get('files').get('f2')
+            f3 = r.get('files').get('f3')
+
+            # simple operations
+            verifier = ContentVerifier()
+            assert verifier.backend.storage.get(f1) is None
+            verfied = verifier.check_file(f1)
+            assert verifier.backend.storage.get(f1) is not None
+            b3 = blake3.blake3()
+            b3.update(open(f1, 'rb').read())
+            assert verfied == b3.hexdigest()
+
+            # incremental processing
+            verifier.start(f2)
+            for chunk in verifier._lazy_read(f2, chunk_size=2):
+                verifier.update(f2, chunk)
+            verifier.finish(f2)
+            incrementally_computed = verifier.backend.storage.get(f2)
+            assert incrementally_computed is not None
+            b3 = blake3.blake3()
+            b3.update(open(f2, 'rb').read())
+            assert incrementally_computed.get('content_hash') == b3.hexdigest()
+
+            # operations on directories
+            d1 = r.get('directories').get('d1')
+
+            # with only files
+            assert len(verifier.check_directory(d1).keys()) == 2
+
+            # with nested directories
+            target_dir = r.get('directories').get('target_dir')
+            assert len(verifier.check_directory(target_dir)) == 4
+
+            # forcing a cache refresh
+            two_days_ago = int((datetime.now() - timedelta(days=2)).timestamp())
+            verifier.backend.storage[f1]['stale_after'] = two_days_ago
+            assert verifier.backend.storage.get(f1).get('stale_after') == two_days_ago
+            verifier.check_directory(target_dir)
+            assert verifier.backend.storage.get(f1).get('stale_after') > two_days_ago
+
+
+    def run_tests_on_verifier_with_backend_and_config(
+        self,
+        cls: GenericBackend,
+        config: dict,
+    ) -> None:
+        # note: unsafe sql param substitution is used here
+        # due to differences in psycopg2 and sqlite3 dialects
+        # being tests only, the trade-off is fine
+        with Resources(self.work_dir) as r:
+
+            # operations on single files
+            f1 = r.get('files').get('f1')
+            f2 = r.get('files').get('f2')
+            f3 = r.get('files').get('f3')
+
+            verifier = ContentVerifier(backend=cls(config=config))
+            backend = verifier.backend
+            engine = verifier.backend.engine
+
+            # first clean anyting left over from previous runs
+            with backend._session_scope(engine) as session:
+                session.execute(
+                    f"delete from content_hashes where reference like '%{self.work_dir}%'"
+                )
+            with backend._session_scope(engine) as session:
+                session.execute(
+                    f"select * from content_hashes where reference = '{f1}'"
+                )
+                result = session.fetchall()
+            assert not result
+
+            # simple operations
+            verfied = verifier.check_file(f1)
+            with backend._session_scope(engine) as session:
+                session.execute(
+                    f"select * from content_hashes where reference = '{f1}'"
+                )
+                result = session.fetchall()
+            assert result
+            b3 = blake3.blake3()
+            b3.update(open(f1, 'rb').read())
+            assert verfied == b3.hexdigest()
+
+            # incremental processing
+            verifier.start(f2)
+            for chunk in verifier._lazy_read(f2, chunk_size=2):
+                verifier.update(f2, chunk)
+            verifier.finish(f2)
+            with backend._session_scope(engine) as session:
+                session.execute(
+                    f"select content_hash from content_hashes where reference = '{f2}'"
+                )
+                result = session.fetchall()
+            assert result is not None
+            b3 = blake3.blake3()
+            b3.update(open(f2, 'rb').read())
+            assert result[0][0] == b3.hexdigest()
+
+            # operations on directories
+            # with only files
+            d1 = r.get('directories').get('d1')
+            assert len(verifier.check_directory(d1).keys()) == 2
+            # with nested directories
+            target_dir = r.get('directories').get('target_dir')
+            assert len(verifier.check_directory(target_dir)) == 4
+
+            # forcing a cache refresh
+            # reset the expiry
+            two_days_ago = int((datetime.now() - timedelta(days=2)).timestamp())
+            with backend._session_scope(engine) as session:
+                session.execute(
+                    f"update content_hashes set stale_after = {two_days_ago} \
+                      where reference = '{f1}'"
+                )
+            with backend._session_scope(engine) as session:
+                session.execute(
+                    f"select stale_after from content_hashes where reference = '{f1}'"
+                )
+                result = session.fetchall()
+            assert result[0][0] == two_days_ago
+            # now refresh it
+            verifier.check_directory(target_dir)
+            with backend._session_scope(engine) as session:
+                session.execute(
+                    f"select stale_after from content_hashes where reference = '{f1}'"
+                )
+                result = session.fetchall()
+            assert result[0][0] > two_days_ago
+
+            # finally clean the db
+            with backend._session_scope(engine) as session:
+                session.execute(
+                    f"delete from content_hashes where reference like '%{self.work_dir}%'"
+                )
+
+    def test_verifier_sqlite(self) -> None:
+        self.run_tests_on_verifier_with_backend_and_config(
+            SQLiteBackend,
+            {"path": "/tmp", "name": "tacl-verifier.db"},
+        )
+
+    def test_verifier_postgres(self) -> None:
+        try:
+            self.run_tests_on_verifier_with_backend_and_config(
+                PostgreSQLBackend,
+                {
+                    "dbname": "apilib_db",
+                    "user": "apilib_user",
+                    "pw": "",
+                    "host": "localhost",
+                },
+            )
+        except psycopg2.OperationalError:
+            print("missing postgres setup - skipping test_verifier_postgres")
+            print("install postgres, and do:")
+            print("createuser apilib_user")
+            print("createdb -O apilib_user apilib_db")

--- a/tsdapilib/verifier.py
+++ b/tsdapilib/verifier.py
@@ -1,0 +1,195 @@
+
+import os
+
+from typing import Iterable, Optional
+
+import blake3
+
+from tsdapilib.backends import GenericBackend, EphemeralBackend
+from tsdapilib.exc import (
+    ContentVerificationReadError,
+    ContentVerificationMissingReferenceError,
+    ContentVerificationReferenceTypeError,
+    ContentVerificationMissingHashError,
+)
+
+
+class ContentVerifier(object):
+
+    """
+    Cached blake3-based content verification of files.
+
+    Examples:
+
+    1. Simple usage on files and directories
+
+    cv = ContentVerifier(backend=PostgreSQLBackend())
+    cv.check_file('/path/to/file') # tries cache first
+    cv.check_file('/path/to/file', force=True) # ignores cache, updates it
+    cv.check_directory('/tmp')
+
+    2. Incremental hashing (useful for stream processing)
+
+    cv.start('/path/to/file') # adds the key, inits the hash func
+    cv.start('/path/to/file', consume=1205) # bytes, to resume
+    cv.update('/path/to/another/file', open(path, 'b').read()[1:offset])
+    cv.update('/path/to/another/file', open(path, 'b').read()[offset:])
+    cv.finish('/path/to/another/file') # returns the hexdigest
+
+    References:
+
+    https://github.com/BLAKE3-team/BLAKE3
+
+    """
+
+    def __init__(
+        self,
+        backend: GenericBackend = EphemeralBackend(),
+    ) -> None:
+        self._backend = backend
+        self._buffer = {}
+
+    @property
+    def backend(self) -> GenericBackend:
+        return self._backend
+
+    @property
+    def buffer(self) -> dict:
+        return self._buffer
+
+    def _lazy_read(
+        self,
+        reference: str,
+        num_bytes: Optional[int] = None,
+        chunk_size: int = 4096,
+    ) -> Iterable:
+        """
+        Read a file, chunk-by-chunk, into an iterable of bytes.
+        If provided, read only until num_bytes, truncating the
+        last chunk size as necessary.
+
+        """
+        with open(reference, 'rb') as f:
+            while True:
+                if num_bytes:
+                    bytes_read = f.tell()
+                    if bytes_read > num_bytes:
+                        raise ContentVerificationReadError
+                    elif bytes_read == num_bytes:
+                        break
+                    elif bytes_read + chunk_size > num_bytes:
+                        # prevent falling into the first branch
+                        chunk_size = num_bytes - bytes_read
+                data = f.read(chunk_size)
+                if not data:
+                    break
+                else:
+                    yield data
+
+    def _consume_reference(
+        self,
+        reference: str,
+        num_bytes: Optional[int] = None,
+    ) -> blake3.blake3:
+        """
+        Consume a given amount of bytes from a file,
+        in a memory efficient way, returning the hash
+        object.
+
+        """
+        b3 = blake3.blake3()
+        for data in self._lazy_read(reference, num_bytes):
+            b3.update(data)
+        return b3
+
+    def _check_path(self, reference: str) -> str:
+        """
+        Ensure the content reference is a valid file path.
+
+        """
+        if not os.path.lexists(reference):
+            raise ContentVerificationMissingReferenceError
+        if os.path.isdir(reference):
+            raise ContentVerificationReferenceTypeError
+        return reference
+
+    # public methods
+
+    def check_file(self, reference: str, force: bool = False) -> Optional[str]:
+        """
+        Return the blake3 hexdigest of a file - either from the cache,
+        or if that was stale or missing, update the cache with a fresh
+        hash, and return it.
+
+        """
+        reference = self._check_path(reference)
+        cached = self.backend.fetch(reference)
+        if cached and not force:
+            return cached.get('content_hash')
+        else:
+            content_hash = self._consume_reference(reference).hexdigest()
+            self.backend.store(reference, content_hash)
+            return content_hash
+
+    def check_directory(self, reference: str, force: bool = False) -> Optional[dict]:
+        """
+        Scan a directory, returning a dict of paths, and their hashes.
+        Behaves the same as check_file, in terms of interaction with
+        the cache, on the individual file level.
+
+        """
+        if not os.path.lexists(reference):
+            raise ContentVerificationMissingReferenceError
+        elif not os.path.isdir(reference):
+            raise ContentVerificationReferenceTypeError
+        out = {}
+        for directory, subdirectory, files in os.walk(reference):
+            for file in files:
+                reference = f"{directory}/{file}"
+                content_hash = self.check_file(reference, force)
+                out[reference] = content_hash
+        return out
+
+    def start(self, reference: str, consume: int = 0) -> None:
+        """
+        Initialise a hash object, optionally consuming some
+        part of a given file. Buffer the initialised object
+        on the instance.
+
+        """
+        reference = self._check_path(reference)
+        if consume:
+            self.buffer[reference] = self._consume_reference(
+                reference, num_bytes=consume,
+            )
+        else:
+            self.buffer[reference] = blake3.blake3()
+
+    def update(self, reference: str, content: bytes) -> None:
+        """
+        Add content to a buffered hash object, associated with
+        a given file reference.
+
+        """
+        reference = self._check_path(reference)
+        b3 = self.buffer.get(reference)
+        if not b3:
+            raise ContentVerificationMissingHashError
+        else:
+            b3.update(content)
+            return True
+
+    def finish(self, reference: str) -> str:
+        """
+        Compute, cache, and return the hexdigest
+        of a buffered hash object.
+
+        """
+        reference = self._check_path(reference)
+        b3 = self.buffer.get(reference)
+        if not b3:
+            raise ContentVerificationMissingHashError
+        else:
+            content_hash = b3.hexdigest()
+            self.backend.store(reference, content_hash)
+            return content_hash


### PR DESCRIPTION
Users often need or want to calculate checksums of the files they upload/download with tacl and the file API. This library will make it simpler to implement efficient content verification of uploads and downloads in tacl and the file API, without unnecessary code duplication.